### PR TITLE
Implement CRC32 checksums

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,6 +86,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "crc"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69e6e4d7b33a94f0991c26729976b10ebde1d34c3ee82408fb536164fa10d636"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+
+[[package]]
 name = "gloo-utils"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -176,6 +191,7 @@ name = "parsing"
 version = "0.1.0"
 dependencies = [
  "chrono",
+ "crc",
  "rust_lzss",
  "serde",
  "tsify",

--- a/parsing/Cargo.toml
+++ b/parsing/Cargo.toml
@@ -15,6 +15,7 @@ rust_lzss = "0.1.1"
 serde = { version = "1.0.219", features = ["derive"] }
 tsify = { version = "0.5.5", optional = true }
 wasm-bindgen = { version = "0.2.100", optional = true }
+crc = "3.2.1"
 
 [dev-dependencies]
 chrono = { version = "0.4.40", default-features = false, features = [


### PR DESCRIPTION
This adds a checksum calculator specifically tailored towards BPK1, as described here: https://www.3dbrew.org/wiki/Swapdoodle#Block_checksum

It uses the crc32 crate and not crc32fast because we need to replace some constants in the algorithm, which crc32fast, to my knowledge, does not allow.

Let me know if anything looks wrong, again, me non speako rusto